### PR TITLE
refactor: extract reader layout state helpers

### DIFF
--- a/apps/desktop/src/renderer/src/shared/lib/reader-layout-state.test.ts
+++ b/apps/desktop/src/renderer/src/shared/lib/reader-layout-state.test.ts
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_READER_LAYOUT_SETTINGS,
+  clampReaderPanelWidth,
+  normalizeReaderLayoutSettings,
+  resolveReaderLayoutClassName,
+} from './reader-layout-state.ts';
+
+test('clampReaderPanelWidth rounds and clamps panel width to desktop reader limits', () => {
+  assert.equal(clampReaderPanelWidth(100), 220);
+  assert.equal(clampReaderPanelWidth(279.6), 280);
+  assert.equal(clampReaderPanelWidth(999), 420);
+});
+
+test('normalizeReaderLayoutSettings fills defaults and keeps explicit false values', () => {
+  assert.deepEqual(normalizeReaderLayoutSettings(null), DEFAULT_READER_LAYOUT_SETTINGS);
+  assert.deepEqual(normalizeReaderLayoutSettings({ showTree: false, showFeedback: false, showToc: false, isDocumentMaximized: true }), {
+    showTree: false,
+    showFeedback: false,
+    showToc: false,
+    isDocumentMaximized: true,
+    treeWidth: 280,
+    rightPanelWidth: 280,
+  });
+});
+
+test('normalizeReaderLayoutSettings migrates old right panel width keys', () => {
+  assert.equal(normalizeReaderLayoutSettings({ feedbackWidth: 310 }).rightPanelWidth, 310);
+  assert.equal(normalizeReaderLayoutSettings({ tocWidth: 315 }).rightPanelWidth, 315);
+  assert.equal(normalizeReaderLayoutSettings({ rightPanelWidth: 320, feedbackWidth: 310, tocWidth: 315 }).rightPanelWidth, 320);
+});
+
+test('resolveReaderLayoutClassName reflects visible reader panels', () => {
+  assert.equal(
+    resolveReaderLayoutClassName({ showTree: true, showFeedback: true, showToc: false, isDocumentMaximized: false }),
+    'document-layout with-tree has-tree has-toc'
+  );
+  assert.equal(
+    resolveReaderLayoutClassName({ showTree: false, showFeedback: false, showToc: false, isDocumentMaximized: true }),
+    'document-layout is-maximized'
+  );
+});

--- a/apps/desktop/src/renderer/src/shared/lib/reader-layout-state.ts
+++ b/apps/desktop/src/renderer/src/shared/lib/reader-layout-state.ts
@@ -1,0 +1,71 @@
+export interface ReaderLayoutSettings {
+  showTree: boolean;
+  showFeedback: boolean;
+  showToc: boolean;
+  isDocumentMaximized: boolean;
+  treeWidth: number;
+  rightPanelWidth: number;
+}
+
+export type PersistedReaderLayoutSettings = Partial<ReaderLayoutSettings> & {
+  tocWidth?: number;
+  feedbackWidth?: number;
+};
+
+export const MIN_READER_PANEL_WIDTH = 220;
+export const MAX_READER_PANEL_WIDTH = 420;
+
+export const DEFAULT_READER_LAYOUT_SETTINGS: ReaderLayoutSettings = {
+  showTree: true,
+  showFeedback: true,
+  showToc: true,
+  isDocumentMaximized: false,
+  treeWidth: 280,
+  rightPanelWidth: 280,
+};
+
+export function clampReaderPanelWidth(width: number) {
+  return Math.min(MAX_READER_PANEL_WIDTH, Math.max(MIN_READER_PANEL_WIDTH, Math.round(width)));
+}
+
+export function normalizeReaderLayoutSettings(parsed: PersistedReaderLayoutSettings | null | undefined): ReaderLayoutSettings {
+  if (!parsed) {
+    return { ...DEFAULT_READER_LAYOUT_SETTINGS };
+  }
+
+  return {
+    showTree: parsed.showTree ?? DEFAULT_READER_LAYOUT_SETTINGS.showTree,
+    showFeedback: parsed.showFeedback ?? DEFAULT_READER_LAYOUT_SETTINGS.showFeedback,
+    showToc: parsed.showToc ?? DEFAULT_READER_LAYOUT_SETTINGS.showToc,
+    isDocumentMaximized: parsed.isDocumentMaximized ?? DEFAULT_READER_LAYOUT_SETTINGS.isDocumentMaximized,
+    treeWidth: clampReaderPanelWidth(parsed.treeWidth ?? DEFAULT_READER_LAYOUT_SETTINGS.treeWidth),
+    rightPanelWidth: clampReaderPanelWidth(parsed.rightPanelWidth ?? parsed.feedbackWidth ?? parsed.tocWidth ?? DEFAULT_READER_LAYOUT_SETTINGS.rightPanelWidth),
+  };
+}
+
+export function hasReaderRightPanel(settings: Pick<ReaderLayoutSettings, 'showFeedback' | 'showToc'>) {
+  return settings.showFeedback || settings.showToc;
+}
+
+export function resolveReaderLayoutClassName(settings: Pick<ReaderLayoutSettings, 'showTree' | 'showFeedback' | 'showToc' | 'isDocumentMaximized'>) {
+  const classNames = ['document-layout'];
+  const hasRightPanel = hasReaderRightPanel(settings);
+
+  if (settings.showTree && hasRightPanel) {
+    classNames.push('with-tree');
+  }
+
+  if (settings.showTree) {
+    classNames.push('has-tree');
+  }
+
+  if (hasRightPanel) {
+    classNames.push('has-toc');
+  }
+
+  if (settings.isDocumentMaximized) {
+    classNames.push('is-maximized');
+  }
+
+  return classNames.join(' ');
+}

--- a/apps/desktop/src/renderer/src/widgets/document/document-reader-layout.tsx
+++ b/apps/desktop/src/renderer/src/widgets/document/document-reader-layout.tsx
@@ -3,18 +3,16 @@
 import { LayoutPanelLeft, ListTree, Maximize2, Minimize2, MessageSquareText } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
-import { readReaderLayoutState, writeReaderLayoutState } from '@/shared/lib/view-state';
+import {
+  clampReaderPanelWidth,
+  hasReaderRightPanel,
+  normalizeReaderLayoutSettings,
+  resolveReaderLayoutClassName,
+  type ReaderLayoutSettings,
+} from '@/shared/lib/reader-layout-state';
 import { cn } from '@/shared/lib/utils';
+import { readReaderLayoutState, writeReaderLayoutState } from '@/shared/lib/view-state';
 import { Button } from '@/shared/ui/button';
-
-interface ReaderLayoutSettings {
-  showTree: boolean;
-  showFeedback: boolean;
-  showToc: boolean;
-  isDocumentMaximized: boolean;
-  treeWidth: number;
-  rightPanelWidth: number;
-}
 
 interface DocumentReaderLayoutProps {
   contentRootKey: string;
@@ -24,17 +22,6 @@ interface DocumentReaderLayoutProps {
   feedback: React.ReactNode;
   toc: React.ReactNode;
 }
-
-const MIN_PANEL_WIDTH = 220;
-const MAX_PANEL_WIDTH = 420;
-const DEFAULT_SETTINGS: ReaderLayoutSettings = {
-  showTree: true,
-  showFeedback: true,
-  showToc: true,
-  isDocumentMaximized: false,
-  treeWidth: 280,
-  rightPanelWidth: 280,
-};
 
 export function DocumentReaderLayout({ contentRootKey, tree, document, maximizedDocument, feedback, toc }: DocumentReaderLayoutProps) {
   const [settings, setSettings] = useState<ReaderLayoutSettings>(() => readLayoutSettings(contentRootKey));
@@ -89,29 +76,9 @@ export function DocumentReaderLayout({ contentRootKey, tree, document, maximized
     };
   }, []);
 
-  const hasRightPanel = settings.showFeedback || settings.showToc;
+  const hasRightPanel = hasReaderRightPanel(settings);
 
-  const layoutClassName = useMemo(() => {
-    const classNames = ['document-layout'];
-
-    if (settings.showTree && hasRightPanel) {
-      classNames.push('with-tree');
-    }
-
-    if (settings.showTree) {
-      classNames.push('has-tree');
-    }
-
-    if (hasRightPanel) {
-      classNames.push('has-toc');
-    }
-
-    if (settings.isDocumentMaximized) {
-      classNames.push('is-maximized');
-    }
-
-    return classNames.join(' ');
-  }, [hasRightPanel, settings.isDocumentMaximized, settings.showTree]);
+  const layoutClassName = useMemo(() => resolveReaderLayoutClassName(settings), [settings]);
 
   const layoutStyle = useMemo(
     () =>
@@ -169,9 +136,9 @@ export function DocumentReaderLayout({ contentRootKey, tree, document, maximized
         ) : (
           <>
             {settings.showTree ? <div className="document-tree-side stack">{tree}</div> : null}
-            {settings.showTree ? <ResizeHandle ariaLabel="좌측 패널 너비 조절" title="트리 너비 조절" onResize={(deltaX) => setSettings((current) => ({ ...current, treeWidth: clampPanelWidth(current.treeWidth + deltaX) }))} /> : null}
+            {settings.showTree ? <ResizeHandle ariaLabel="좌측 패널 너비 조절" title="트리 너비 조절" onResize={(deltaX) => setSettings((current) => ({ ...current, treeWidth: clampReaderPanelWidth(current.treeWidth + deltaX) }))} /> : null}
             <div className="document-main stack">{document}</div>
-            {hasRightPanel ? <ResizeHandle ariaLabel="우측 패널 너비 조절" title="우측 패널 너비 조절" onResize={(deltaX) => setSettings((current) => ({ ...current, rightPanelWidth: clampPanelWidth(current.rightPanelWidth - deltaX) }))} /> : null}
+            {hasRightPanel ? <ResizeHandle ariaLabel="우측 패널 너비 조절" title="우측 패널 너비 조절" onResize={(deltaX) => setSettings((current) => ({ ...current, rightPanelWidth: clampReaderPanelWidth(current.rightPanelWidth - deltaX) }))} /> : null}
             {hasRightPanel ? <div className="document-side stack">{settings.showFeedback ? feedback : null}{settings.showToc ? toc : null}</div> : null}
           </>
         )}
@@ -218,24 +185,8 @@ function ResizeHandle({ onResize, ariaLabel, title }: { onResize: (deltaX: numbe
   );
 }
 
-function clampPanelWidth(width: number) {
-  return Math.min(MAX_PANEL_WIDTH, Math.max(MIN_PANEL_WIDTH, Math.round(width)));
-}
-
 function readLayoutSettings(contentRootKey: string): ReaderLayoutSettings {
-  const parsed = readReaderLayoutState(contentRootKey) as (Partial<ReaderLayoutSettings> & { tocWidth?: number; feedbackWidth?: number }) | null;
-  if (!parsed) {
-    return DEFAULT_SETTINGS;
-  }
-
-  return {
-    showTree: parsed.showTree ?? true,
-    showFeedback: parsed.showFeedback ?? true,
-    showToc: parsed.showToc ?? true,
-    isDocumentMaximized: parsed.isDocumentMaximized ?? false,
-    treeWidth: clampPanelWidth(parsed.treeWidth ?? DEFAULT_SETTINGS.treeWidth),
-    rightPanelWidth: clampPanelWidth(parsed.rightPanelWidth ?? parsed.feedbackWidth ?? parsed.tocWidth ?? DEFAULT_SETTINGS.rightPanelWidth),
-  };
+  return normalizeReaderLayoutSettings(readReaderLayoutState(contentRootKey));
 }
 
 function writeLayoutSettings(contentRootKey: string, settings: ReaderLayoutSettings) {

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -18,5 +18,5 @@
     "src/renderer/src/**/*.d.ts",
     "electron.vite.config.ts"
   ],
-  "exclude": ["node_modules", "out", "dist"]
+  "exclude": ["node_modules", "out", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- Extract reader layout defaults, width clamping, persisted-state normalization, and layout class resolution into a testable shared helper.
- Keep `DocumentReaderLayout` focused on rendering and event wiring.
- Add Node test coverage for layout state normalization, legacy right-panel width migration, class names, and clamping.

Closes #100

## Verification
- `pnpm --filter @markdeck/desktop test`
- `pnpm --filter @markdeck/desktop typecheck`
- `pnpm --filter @markdeck/desktop build`

Note: Node emits the existing ESM parse warning for the new `.test.ts` file, but the test suite passes.
