### PR TITLE
docs: refresh desktop architecture boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,16 @@ MarkDeck은 현재 **Electron + electron-vite 기반 desktop app** 입니다.
 
 런타임은 아래 세 층으로 분리되어 있습니다.
 
-- **main** → 파일 시스템 / search / asset read / desktop integration
-- **IPC** → typed contract
-- **renderer** → UI / routing / review workflow
+- **main** (`apps/desktop/src/main`) → 파일 시스템 / search / asset read / desktop integration
+- **preload** (`apps/desktop/src/preload`) → renderer에 노출되는 최소 IPC bridge
+- **renderer** (`apps/desktop/src/renderer/src`) → UI / routing / review workflow
 
 desktop main은 `fluffy-comics` 구조를 참고해 hexagonal architecture 경계를 드러내는 형태로 정리되어 있습니다.
 
-- **core** → 순수 규칙 / 정책
-- **application** → 유스케이스 오케스트레이션
-- **infrastructure/electron** → 메뉴 / shell / Electron boundary
-- **infrastructure/node** → config / content / watcher / process access
+- **core** (`src/main/core`) → 순수 규칙 / 정책
+- **application** (`src/main/application`) → 유스케이스 오케스트레이션
+- **infrastructure/electron** (`src/main/infrastructure/electron`) → 메뉴 / shell / Electron boundary
+- **infrastructure/node** (`src/main/infrastructure/node`) → config / content / watcher / process access
 
 현재 desktop에서 이미 반영된 것:
 
@@ -190,10 +190,14 @@ markdeck/
 
 renderer 쪽은 현재 실용적인 FSD 방향으로 정리 중입니다.
 
-- `platform/desktop/renderer` → desktop renderer bootstrap / bridge / IPC adapter
+- `platform/desktop/renderer` → desktop renderer bootstrap / bridge / IPC adapter / React Query hooks
 - `views/desktop/*` → desktop route 단위 page composition
+- `features/*` → 검색, 테마처럼 독립 기능에 가까운 UI 단위
 - `widgets/desktop/*` → desktop shell 주변 UI(command palette, shortcut help, refresh status)
 - `widgets/document|navigation|layout` → page 조합에 재사용되는 UI 블록
+- `shared/lib|ui|types` → 순수 helper, 공용 UI primitive, IPC/desktop 타입
+
+현재 우선순위는 `TODO.md` 기준으로 renderer 구조 정리 → README/architecture docs 최신화 → 그 이후 annotation persistence 같은 큰 feature 재개 순서입니다.
 
 ---
 

--- a/docs/desktop-architecture-review.md
+++ b/docs/desktop-architecture-review.md
@@ -1,85 +1,68 @@
 # Desktop architecture review
 
-## 1st phase: Electron wraps the current web app
+## Current direction
 
-### Pros
+MarkDeck is now a **desktop-first Electron app** built with `electron-vite`.
+The earlier "Electron wraps the web app" phase has been replaced by a hybrid desktop structure where Electron main owns local capabilities and the renderer is a client UI.
 
-- fastest path to a usable desktop app
-- existing routing / markdown rendering / search code stays intact
-- low-risk migration from current web-first structure
+## Runtime model
 
-### Cons
+- **main** (`apps/desktop/src/main`) owns content roots, recent workspaces, launch target handling, watcher lifecycle, local file reads, asset reads, and search.
+- **preload** (`apps/desktop/src/preload`) exposes the minimum IPC bridge to the renderer.
+- **renderer** (`apps/desktop/src/renderer/src`) owns route state, React Query state, reading/review UI, and annotation draft UX.
 
-- desktop runtime still feels like a small local web stack
-- content root changes currently restart the dev web process
-- filesystem/search logic still lives on the web/server side
+The desktop main structure follows a hexagonal split:
 
-## Long-term options
+- `core` for pure rules and policy
+- `application` for use-case orchestration
+- `infrastructure/electron` for Electron shell/menu/window boundaries
+- `infrastructure/node` for filesystem/config/content watcher boundaries
 
-### Option A. Keep Next.js-driven local server inside desktop
+## Why this direction
 
-**Good for**
-- fastest delivery
-- reuse of current app/router code
-- minimal rewrite cost
+### Benefits
 
-**Trade-offs**
-- desktop app depends on embedded local server behavior
-- packaging/runtime complexity stays higher
+- Desktop-specific filesystem behavior lives in the process that can safely access it.
+- Renderer code can stay focused on UI composition and query state.
+- IPC contracts make the main/preload/renderer boundary easier to test and review.
+- Packaging no longer depends on a separate local web server mental model.
 
-### Option B. Hybrid desktop architecture
+### Trade-offs
 
-Move filesystem/search/document-loading logic into Electron main, and let renderer focus on UI only.
+- IPC payloads and error shapes need deliberate naming/versioning discipline.
+- Renderer views can still become large if data derivation and layout policy stay inline too long.
+- Some main runtime modules are still JavaScript, so TypeScript conversion remains a follow-up hardening path.
 
-**Good for**
-- more natural desktop boundary
-- content root and file access become first-class desktop capabilities
-- better control over caching, indexing, and security boundaries
+## Current status (2026-05-09)
 
-**Trade-offs**
-- requires API bridge design between renderer and main
-- more refactoring around routes/data fetching
+Already in place:
 
-### Option C. Static renderer + Electron-only backend bridge
+- electron-vite separate `main / preload / renderer` build
+- desktop main `core / application / infrastructure` organization
+- content root selection and recent workspace persistence in Electron main
+- directory browsing, document loading, asset reads, search, and watcher refresh through IPC-backed flows
+- renderer `HashRouter` + React Query data flow
+- desktop shell UI, command palette, shortcut help, refresh status, reader layout controls
+- main-process regression tests for launch/content-root/watcher/application behavior
 
-Replace server-driven document reads with IPC/data APIs, and keep the renderer as a client app.
+Recently prioritized cleanup:
 
-**Good for**
-- closest to a serverless desktop experience
-- packaging can become simpler in the long run
+1. Continue practical renderer structure cleanup.
+2. Keep README and architecture docs aligned with the implemented desktop-first structure.
+3. Resume larger feature work such as `.memo` persistence after boundaries are clearer.
 
-**Trade-offs**
-- largest migration cost
-- markdown/document/search flow needs redesign
+## Remaining candidates
 
-## Recommended path
+- Convert remaining desktop main runtime modules from JavaScript to TypeScript.
+- Remove the `sync-main-runtime.mjs` compatibility copy step once the main runtime is fully electron-vite friendly.
+- Tighten IPC request/response naming and error payload consistency.
+- Add renderer integration smoke coverage for route restore, content root switching, and IPC-backed query flows.
+- Add packaged-app smoke coverage for launch/open/browse/read/search/annotation draft paths.
 
-1. **Now**: keep Electron wrapping the current web app.
-2. **Next**: move content root selection, file reads, directory traversal, and search indexing into Electron main.
-3. **Later**: evaluate whether the renderer can become fully serverless/hybrid without a Next server.
+## Related docs
 
-## Current status (2026-03-12)
-
-The desktop path has now started this migration:
-
-- content root selection/persistence lives in Electron main
-- desktop browse refresh can load directory entries through Electron IPC
-- desktop document refresh can load markdown content, sibling tree data, and known markdown paths through Electron IPC
-- web routes still keep the server-side implementation as the initial render/fallback path
-
-So the current model is intentionally **hybrid**:
-
-- initial page render: Next.js server path
-- desktop hydration/update path: Electron preload/API → main process filesystem access
-
-This keeps the current Electron-wraps-web structure, while starting to move the file exploration/read boundary into Electron main.
-
-## Migration candidates for Electron main
-
-- content root persistence
-- directory listing
-- markdown file reads
-- asset reads
-- search indexing / query execution
-
-This keeps the current 1차 Electron 방향을 유지하면서도, 장기적으로는 서버를 별도로 느끼지 않는 구조로 갈 수 있는 이행 경로를 남깁니다.
+- [`platform-boundaries.md`](./platform-boundaries.md)
+- [`desktop-cache-strategy.md`](./desktop-cache-strategy.md)
+- [`desktop-packaging.md`](./desktop-packaging.md)
+- [`markdown-source-render-mapping.md`](./markdown-source-render-mapping.md)
+- [`split-view-editor-preview-plan.md`](./split-view-editor-preview-plan.md)

--- a/docs/platform-boundaries.md
+++ b/docs/platform-boundaries.md
@@ -1,23 +1,38 @@
 # Platform boundaries
 
-MarkDeck now runs as a **desktop-first Electron app** with an `electron-vite` renderer. Filesystem access stays in Electron main and the renderer talks only through preload IPC.
+MarkDeck now runs as a **desktop-first Electron app** built with `electron-vite`.
+Filesystem and OS access stay in Electron main; the renderer talks through the preload IPC bridge and keeps UI/query state client-side.
 
-## Layers
+## Runtime layers
 
-### Shared
+### Electron main
 
-Location examples:
+Location:
 
-- `apps/desktop/src/renderer/src/shared/lib/content-types.ts`
-- `apps/desktop/src/renderer/src/shared/lib/content-links.ts`
-- `apps/desktop/src/renderer/src/shared/lib/markdown.ts`
-- `apps/desktop/src/renderer/src/shared/lib/assets.ts`
+- `apps/desktop/src/main/index.ts`
+- `apps/desktop/src/main/core/*`
+- `apps/desktop/src/main/application/*`
+- `apps/desktop/src/main/infrastructure/electron/*`
+- `apps/desktop/src/main/infrastructure/node/*`
 
-Rules:
+Responsibilities:
 
-- pure data shapes and pure string/markdown/path helpers only
-- no `window`, Electron IPC, `fs`, or Next route handlers here
-- safe to use from renderer components and desktop IPC payloads
+- own content root persistence, recent roots, launch target handling, and watcher lifecycle
+- read local markdown/assets and execute search through Node-side infrastructure
+- expose use-case oriented IPC handlers instead of leaking filesystem primitives
+- keep pure rules in `core`, orchestration in `application`, and side effects in `infrastructure/*`
+
+### Preload
+
+Location:
+
+- `apps/desktop/src/preload/index.ts`
+
+Responsibilities:
+
+- expose the minimum `markdeckDesktop` bridge used by the renderer
+- keep IPC channel names and payload shapes explicit
+- avoid exposing raw Electron or Node APIs to renderer code
 
 ### Desktop renderer adapter
 
@@ -25,45 +40,55 @@ Location:
 
 - `apps/desktop/src/renderer/src/platform/desktop/renderer/desktop-api.ts`
 - `apps/desktop/src/renderer/src/platform/desktop/renderer/desktop-queries.ts`
+- `apps/desktop/src/renderer/src/platform/desktop/renderer/desktop-router.tsx`
+- `apps/desktop/src/renderer/src/platform/desktop/renderer/desktop-shell.tsx`
+
+Responsibilities:
+
+- adapt the preload bridge into typed renderer-facing functions
+- own React Query keys/hooks for desktop data access
+- own desktop routing/bootstrap concerns such as `HashRouter`
+- keep route/query state in the renderer; never import `fs` or Electron main modules
+
+### Renderer UI boundaries
+
+Location examples:
+
+- `apps/desktop/src/renderer/src/views/desktop/*`
+- `apps/desktop/src/renderer/src/features/*`
+- `apps/desktop/src/renderer/src/widgets/*`
+- `apps/desktop/src/renderer/src/shared/*`
 
 Rules:
 
-- renderer never touches `fs` directly
-- renderer reads content only through preload-exposed IPC
-- route state and query state stay on the renderer side
+- `views/desktop/*`: route-level page composition only
+- `features/*`: focused feature UI such as search or theme controls
+- `widgets/*`: reusable page sections and desktop/document/navigation UI blocks
+- `shared/lib`: pure data shapes and helpers only; no `window`, Electron IPC, `fs`, or route components
+- `shared/ui`: reusable UI primitives without app-specific data fetching
+- `shared/types`: ambient desktop/preload types
 
-### Desktop main / preload
+## Current desktop data flow
 
-Location:
-
-- `apps/desktop/src/main/index.js`
-- `apps/desktop/src/preload/index.js`
-- `apps/desktop/main/**/*`
-
-Rules:
-
-- renderer never touches Node/fs directly
-- renderer calls preload API
-- Electron main owns content root persistence and local filesystem reads
-
-## Current flow
-
-- electron-vite loads the renderer from `src/renderer`
-- preload exposes the `markdeckDesktop` bridge
-- Electron main handles content root, watcher, search, and local file reads
-- renderer updates route/query state entirely on the client via `HashRouter` + React Query
+1. `electron-vite` loads main, preload, and renderer from separate entrypoints.
+2. Preload exposes the `markdeckDesktop` bridge.
+3. Renderer adapter functions call the bridge and wrap the results in React Query hooks.
+4. Electron main handles content root, watcher, search, local file reads, and asset reads.
+5. Renderer updates route/query/UI state entirely on the client via `HashRouter` + React Query.
 
 ## Migration guideline
 
 When adding new content access behavior:
 
-1. put reusable shapes/helpers in **shared**
-2. put renderer-side access in **desktop renderer adapter**
-3. put filesystem / OS access in **Electron main or preload**
-4. avoid importing Node-only code into renderer components
+1. Put reusable shapes/helpers in `shared`.
+2. Put renderer-side bridge/query access in `platform/desktop/renderer`.
+3. Put filesystem, OS, watcher, or process access in Electron main infrastructure.
+4. Add application/core helpers when the behavior has reusable policy or orchestration.
+5. Avoid importing Node-only code into renderer components.
 
 ## Near-term follow-up
 
-- keep renderer route/view code independent from Electron internals
-- keep search/indexing and asset loading behind the same IPC boundary
-- move any remaining legacy `main/*` internals under `src/main` when the churn is worth it
+- Continue the practical renderer structure cleanup before larger feature work.
+- Keep search/indexing and asset loading behind the same IPC boundary.
+- Keep IPC request/response names and error payloads consistent.
+- Update this document when a new boundary or package-level convention is introduced.


### PR DESCRIPTION
## Summary
- Refresh README desktop architecture paths and renderer boundary notes.
- Rewrite platform boundary docs around the current main/preload/renderer split.
- Update the desktop architecture review away from the older Electron-wraps-web framing and record current follow-ups.

Closes #101

## Verification
- `pnpm --filter @markdeck/desktop test`
- `pnpm --filter @markdeck/desktop typecheck`
