### PR TITLE
test: add renderer route smoke coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ release
 .env*
 !.env.example
 .DS_Store
+*.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ desktop main은 `fluffy-comics` 구조를 참고해 hexagonal architecture 경�
 - [`docs/desktop-cache-strategy.md`](./docs/desktop-cache-strategy.md)
 - [`docs/desktop-packaging.md`](./docs/desktop-packaging.md)
 - [`docs/electron-runtime-comparison.md`](./docs/electron-runtime-comparison.md)
+- [`docs/renderer-integration-testing.md`](./docs/renderer-integration-testing.md)
 
 ---
 

--- a/apps/desktop/src/main/infrastructure/electron/create-electron-menu-adapter.js
+++ b/apps/desktop/src/main/infrastructure/electron/create-electron-menu-adapter.js
@@ -1,4 +1,3 @@
-const { Menu } = require('electron');
 const { buildApplicationMenuTemplate } = require('./application-menu');
 
 function createElectronMenuAdapter({ isDev }) {
@@ -12,6 +11,7 @@ function createElectronMenuAdapter({ isDev }) {
       });
     },
     set(template) {
+      const { Menu } = require('electron');
       Menu.setApplicationMenu(Menu.buildFromTemplate(template));
     },
   };

--- a/apps/desktop/src/renderer/src/platform/desktop/renderer/desktop-queries.ts
+++ b/apps/desktop/src/renderer/src/platform/desktop/renderer/desktop-queries.ts
@@ -16,6 +16,7 @@ import {
   searchDesktopMarkdownDocuments,
 } from '@/platform/desktop/renderer/desktop-api';
 import { isDesktopRenderer } from '@/platform/desktop/renderer/desktop-api';
+import { loadDesktopDocumentPageData } from '@/platform/desktop/renderer/desktop-query-flows';
 import { createAppHref } from '@/shared/lib/app-routes';
 
 export const desktopQueryKeys = {
@@ -84,20 +85,12 @@ export function useDesktopDocumentTreeQuery(relativePath: string, depth = 1, ena
 export function useDesktopDocumentPageQuery(relativePath: string, enabled = true) {
   return useQuery({
     queryKey: desktopQueryKeys.documentPage(relativePath),
-    queryFn: async () => {
-      const directoryPath = relativePath.split('/').slice(0, -1).join('/');
-      const [document, knownDocuments, sidebarTree] = await Promise.all([
-        readDesktopMarkdownDocument(relativePath),
-        collectDesktopMarkdownRelativePaths(),
-        buildDesktopDocumentTree(directoryPath, 1),
-      ]);
-
-      return {
-        document,
-        knownDocuments,
-        sidebarTree,
-      };
-    },
+    queryFn: () =>
+      loadDesktopDocumentPageData(relativePath, {
+        readMarkdownDocument: readDesktopMarkdownDocument,
+        collectMarkdownRelativePaths: collectDesktopMarkdownRelativePaths,
+        buildDocumentTree: buildDesktopDocumentTree,
+      }),
     enabled: enabled && isDesktopRenderer() && Boolean(relativePath),
   });
 }

--- a/apps/desktop/src/renderer/src/platform/desktop/renderer/desktop-query-flows.test.ts
+++ b/apps/desktop/src/renderer/src/platform/desktop/renderer/desktop-query-flows.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getDesktopDocumentDirectoryPath, loadDesktopDocumentPageData } from './desktop-query-flows.ts';
+
+test('getDesktopDocumentDirectoryPath resolves the sidebar tree root for document routes', () => {
+  assert.equal(getDesktopDocumentDirectoryPath('Guide.md'), '');
+  assert.equal(getDesktopDocumentDirectoryPath('docs/nested/Guide.md'), 'docs/nested');
+});
+
+test('loadDesktopDocumentPageData composes the IPC-backed document page flow', async () => {
+  const calls: string[] = [];
+  const document = {
+    absolutePath: '/vault/docs/Guide.md',
+    relativePath: 'docs/Guide.md',
+    content: '# Guide',
+    title: 'Guide',
+    size: 7,
+    updatedAt: '2026-07-28T00:00:00.000Z',
+  };
+  const sidebarTree = [
+    {
+      name: 'Guide.md',
+      relativePath: 'docs/Guide.md',
+      type: 'markdown' as const,
+    },
+  ];
+
+  const result = await loadDesktopDocumentPageData('docs/Guide.md', {
+    readMarkdownDocument: async (relativePath) => {
+      calls.push(`document:${relativePath}`);
+      return document;
+    },
+    collectMarkdownRelativePaths: async () => {
+      calls.push('known-documents');
+      return ['docs/Guide.md', 'README.md'];
+    },
+    buildDocumentTree: async (relativePath, depth) => {
+      calls.push(`tree:${relativePath}:${depth}`);
+      return sidebarTree;
+    },
+  });
+
+  assert.deepEqual(calls.sort(), ['document:docs/Guide.md', 'known-documents', 'tree:docs:1']);
+  assert.deepEqual(result, {
+    document,
+    knownDocuments: ['docs/Guide.md', 'README.md'],
+    sidebarTree,
+  });
+});

--- a/apps/desktop/src/renderer/src/platform/desktop/renderer/desktop-query-flows.ts
+++ b/apps/desktop/src/renderer/src/platform/desktop/renderer/desktop-query-flows.ts
@@ -1,0 +1,35 @@
+import type { DocumentTreeNode, MarkdownDocument } from '@/shared/lib/content-types';
+
+export interface DesktopDocumentPageData {
+  document: MarkdownDocument | null;
+  knownDocuments: string[];
+  sidebarTree: DocumentTreeNode[];
+}
+
+export interface DesktopDocumentPageServices {
+  readMarkdownDocument: (relativePath: string) => Promise<MarkdownDocument | null>;
+  collectMarkdownRelativePaths: () => Promise<string[]>;
+  buildDocumentTree: (relativePath: string, depth: number) => Promise<DocumentTreeNode[]>;
+}
+
+export function getDesktopDocumentDirectoryPath(relativePath: string) {
+  return relativePath.split('/').slice(0, -1).join('/');
+}
+
+export async function loadDesktopDocumentPageData(
+  relativePath: string,
+  services: DesktopDocumentPageServices
+): Promise<DesktopDocumentPageData> {
+  const directoryPath = getDesktopDocumentDirectoryPath(relativePath);
+  const [document, knownDocuments, sidebarTree] = await Promise.all([
+    services.readMarkdownDocument(relativePath),
+    services.collectMarkdownRelativePaths(),
+    services.buildDocumentTree(directoryPath, 1),
+  ]);
+
+  return {
+    document,
+    knownDocuments,
+    sidebarTree,
+  };
+}

--- a/apps/desktop/src/renderer/src/shared/lib/app-routes.test.ts
+++ b/apps/desktop/src/renderer/src/shared/lib/app-routes.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createAppHref, getDesktopHashHref, parseAppRoute } from './app-routes.ts';
+
+test('createAppHref normalizes desktop renderer paths and search params', () => {
+  assert.equal(createAppHref('browse/docs/', 'q=hello'), '/browse/docs?q=hello');
+  assert.equal(createAppHref('/', '?q=hello'), '/?q=hello');
+});
+
+test('getDesktopHashHref creates HashRouter-compatible desktop links', () => {
+  assert.equal(getDesktopHashHref('/docs/Guide.md'), '/desktop#/docs/Guide.md');
+  assert.equal(getDesktopHashHref('/search', 'q=Guide'), '/desktop#/search?q=Guide');
+});
+
+test('parseAppRoute decodes route segments and search query state', () => {
+  assert.deepEqual(parseAppRoute('/browse/Folder%20A/Nested'), {
+    kind: 'browse',
+    segments: ['Folder A', 'Nested'],
+  });
+  assert.deepEqual(parseAppRoute('/docs/Folder%20A/Guide.md'), {
+    kind: 'document',
+    segments: ['Folder A', 'Guide.md'],
+  });
+  assert.deepEqual(parseAppRoute('/search', '?q=%20markdown%20'), {
+    kind: 'search',
+    query: 'markdown',
+  });
+});

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -18,5 +18,5 @@
     "src/renderer/src/**/*.d.ts",
     "electron.vite.config.ts"
   ],
-  "exclude": ["node_modules", "out", "dist"]
+  "exclude": ["node_modules", "out", "dist", "src/**/*.test.ts"]
 }

--- a/docs/renderer-integration-testing.md
+++ b/docs/renderer-integration-testing.md
@@ -1,0 +1,44 @@
+# Renderer integration testing
+
+## Goal
+
+Renderer tests should protect the desktop client flows that are most likely to regress while MarkDeck keeps moving filesystem behavior into Electron main.
+
+Near-term smoke coverage should focus on:
+
+1. **Route state**: `HashRouter` path/search helpers, browse/document/search route parsing, and route reset behavior after content root changes.
+2. **Content root switching**: renderer mutations should reset the route to `/`, update the content root cache, and invalidate content/search/asset query groups.
+3. **IPC-backed query flows**: document pages should fetch document content, known document paths, and sidebar tree data through the desktop renderer adapter rather than touching filesystem code directly.
+
+## Current lightweight harness
+
+The project currently uses Node's built-in test runner via:
+
+```bash
+pnpm --filter @markdeck/desktop test
+```
+
+For pure renderer helpers, add colocated `*.test.ts` files and import the helper with a relative `.ts` extension. Node 22 can execute these tests directly. TypeScript app typechecking excludes `*.test.ts` files because the app build does not enable `allowImportingTsExtensions`.
+
+Example currently covered:
+
+- `apps/desktop/src/renderer/src/shared/lib/app-routes.test.ts`
+  - verifies desktop app href normalization
+  - verifies `/desktop#...` HashRouter link generation
+  - verifies browse/document/search route parsing and decoding
+
+## Next harness step
+
+For React Query + mutation smoke tests, add a small renderer test harness that can provide:
+
+- a fake `window.markdeckDesktop` preload bridge
+- a `QueryClient` instance
+- route/hash assertions around content root changes
+
+Candidate tests:
+
+- `useChooseDesktopContentRootMutation` resets `window.location.hash` to `/` and invalidates desktop content query groups.
+- `useDesktopDocumentPageQuery` composes `readDesktopMarkdownDocument`, `collectDesktopMarkdownRelativePaths`, and `buildDesktopDocumentTree` for the selected relative path.
+- search queries stay disabled for blank search text.
+
+If the project adds a DOM test runner later, prefer Vitest + jsdom or Playwright component-level smoke tests. Until then, keep renderer tests pure and close to shared/adapter helpers.


### PR DESCRIPTION
## Summary
- Add renderer route smoke tests for app href normalization, desktop HashRouter links, and route parsing.
- Document the renderer integration testing strategy and next React Query/preload bridge harness step.
- Exclude `*.test.ts` from app typecheck because Node executes TS tests through relative `.ts` imports.

Closes #102

## Verification
- `pnpm --filter @markdeck/desktop test`
- `pnpm --filter @markdeck/desktop typecheck`
- `pnpm --filter @markdeck/desktop build`

Note: Node emits a module-type parse warning for `.test.ts`, but all tests pass.
